### PR TITLE
Change IP to allow listening from any host

### DIFF
--- a/lib/starling/server_runner.rb
+++ b/lib/starling/server_runner.rb
@@ -14,7 +14,7 @@ module StarlingServer
     def self.run
       new
     end
-    
+
     def self.shutdown
       @@instance.shutdown
     end
@@ -69,7 +69,7 @@ module StarlingServer
     end
 
     def parse_options
-      self.options = { :host => '127.0.0.1',
+      self.options = { :host => '0.0.0.0',
                        :port => 22122,
                        :path => File.join('', 'var', 'spool', 'starling'),
                        :log_level => Logger::INFO,


### PR DESCRIPTION
To allow connections to starling from outside of container, starling needs to listen to 0.0.0.0 ip address. Otherwise connections from outside are not possible.